### PR TITLE
use blake2 from python stdlib if available (py3.6+)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ ecdsa>=0.9
 mnemonic>=0.17
 requests>=2.4.0
 click>=6.2
-pyblake2>=0.9.3
 hidapi>=0.7.99.post20
 libusb1>=1.6.4
+pyblake2>=0.9.3 ; python_version<'3.6'

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ install_requires = [
     'mnemonic>=0.17',
     'requests>=2.4.0',
     'click>=6.2',
-    'pyblake2>=0.9.3',
+    "pyblake2>=0.9.3 ; python_version<'3.6'",
 ]
 
 import sys

--- a/trezorlib/client.py
+++ b/trezorlib/client.py
@@ -1193,10 +1193,13 @@ class ProtocolMixin(object):
 
         # TREZORv2 method
         if isinstance(resp, proto.FirmwareRequest):
-            import pyblake2
+            try:
+                from hashlib import blake2s
+            except ImportError:
+                from pyblake2 import blake2s
             while True:
                 payload = data[resp.offset:resp.offset + resp.length]
-                digest = pyblake2.blake2s(payload).digest()
+                digest = blake2s(payload).digest()
                 resp = self.call(proto.FirmwareUpload(payload=payload, hash=digest))
                 if isinstance(resp, proto.FirmwareRequest):
                     continue


### PR DESCRIPTION
This is a port of https://github.com/trezor/trezor-firmware/commit/6d407c84d7dae44a162b55110c08e76b71fb0b7f

There is no reason to use the pyblake2 package on python 3.6+ as it is now [part of the stdlib](https://github.com/dchest/pyblake2/commit/5cd043a7e4be741a7f21c20d8c27a73302f25975).
It is always good to remove unnecessary dependencies.
Further, there is [no pre-built wheel](https://pypi.org/project/pyblake2/#files) for pyblake2 for python3.7 and python3.8.

Please merge this and also release a new version of the library on PyPI, as I would like to use it in Electrum. This is blocking increasing the Python interpreter version in our Windows binaries.